### PR TITLE
Fix pgmspace.h include for ESP32

### DIFF
--- a/DES_config.h
+++ b/DES_config.h
@@ -30,8 +30,10 @@
 	typedef unsigned char byte;
 	#define printf_P printf
 	#define PSTR(x) (x)
-#else
+#elif defined(__AVR__) || defined(ARDUINO_ARCH_AVR)
 	#include <avr/pgmspace.h>
+#else
+	#include <pgmspace.h>
 #endif
 
 #endif


### PR DESCRIPTION
The include `<avr/pgmspace.h>` does not exist on non-avr platforms such as the ESP32.
This PR fixes this problem similar to [here](https://github.com/TheThingsNetwork/arduino-device-lib/pull/243).

Tested on Arduino Nano and ESP32 Dev Module