### PR TITLE
Add PlatformIO support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,26 @@ ArduinoDES
 DES and Triples DES encryption and decryption library for the Arduino microcontroller platform.
 This code was ported from the AVR-Crypto-Lib (http://www.das-labor.org/wiki/AVR-Crypto-Lib).
 
+Arduino IDE
+-----------
+
 To install the library, download and copy the files into a subfolder (e.g. "DES") in the 
 "libraries" folder of your Arduino development environment.
 
 The library was tested on an Arduino Leonardo and works on an Intel Galileo board, too (thanks spaniakos).
+
+
+PlatformIO
+----------
+
+To use this library in a PlatformIO project, add this repository's url to the list of `lib_deps` in `platformio.ini`.
+Make sure to use `framework = arduino`:
+
+```
+framework = arduino
+lib_deps =
+    https://github.com/Octoate/ArduinoDES.git
+```
 
 
 Usage

--- a/library.json
+++ b/library.json
@@ -1,0 +1,13 @@
+{
+    "name": "ArduinoDES",
+    "version": "1.0.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Octoate/ArduinoDES.git"
+    },
+    "frameworks": ["arduino"],
+    "platforms": "*",
+    "build": {
+        "srcFilter": ["+<*.cpp>", "+<*.h>"]
+    }
+}


### PR DESCRIPTION
* This PR allows using this library out of the box in PlatformIO
* Previously this failed because the tool tried to also compile the files in `examples_Rpi` for the target microcontroller. This is now prevented by restricting the `srcFilter` to top-level source files